### PR TITLE
feat: 이메일, 닉네임 수정 기능 구현

### DIFF
--- a/be/src/main/java/capstone/be/domain/user/controller/UserEditController.java
+++ b/be/src/main/java/capstone/be/domain/user/controller/UserEditController.java
@@ -1,0 +1,58 @@
+package capstone.be.domain.user.controller;
+
+import capstone.be.domain.user.dto.EmailEditDto;
+import capstone.be.domain.user.dto.NicknameEditDto;
+import capstone.be.domain.user.service.EditUserService;
+import capstone.be.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+//Todo : 회원 탈퇴는 uri 에 맞게 SignController로 옮겨야 할 것 같음.(일단 코드 리뷰할 때 보기 편하도록 한 파일에 넣어뒀음
+// + 유저 정보 delete 후 토큰은 어떻게 처리해야 하는지..?
+// 유저를 찾을 수 없을 때 발생하는 exception이 에러코드에 적힌 AUTH_010에 해당하는 것 같다. yml에 적힌 이름을 바꾸는 게 좋지 않을까?
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/user/update")
+public class UserEditController {
+    private final JwtProvider jwtProvider;
+    private final EditUserService editUserService;
+
+    //닉네임 변경
+    @PatchMapping("/nickname")
+    public ResponseEntity<NicknameEditDto> updateNickname(@RequestBody NicknameEditDto request, HttpServletRequest tokenRequest) {
+        String accessToken = jwtProvider.resolveToken(tokenRequest);
+        // 엑세스 토큰으로 userId를 받아서 유저 찾기
+        Long userId = Long.parseLong(jwtProvider.getSubjects(accessToken));
+
+        NicknameEditDto newNickname = editUserService.editNickname(userId, request.getNickname());
+
+        return ResponseEntity.ok(newNickname);
+    }
+
+    //이메일 변경
+    @PatchMapping("/email")
+    public ResponseEntity<EmailEditDto> updateEmail(@RequestBody EmailEditDto request, HttpServletRequest tokenRequest) {
+        String accessToken = jwtProvider.resolveToken(tokenRequest);
+        Long userId = Long.parseLong(jwtProvider.getSubjects(accessToken));
+
+        EmailEditDto newEmail = editUserService.editEmail(userId, request.getEmail());
+
+        return ResponseEntity.ok(newEmail);
+    }
+
+    //회원 탈퇴 -> 일단 deltet로 유저 정보만 삭제하도록 구현
+    @DeleteMapping("/delete")
+    public ResponseEntity<String> deleteUser(HttpServletRequest request){
+        String accessToken = jwtProvider.resolveToken(request);
+        Long userId = Long.parseLong(jwtProvider.getSubjects(accessToken));
+        editUserService.deleteUser(userId);
+
+        return ResponseEntity.ok("");
+    }
+}

--- a/be/src/main/java/capstone/be/domain/user/dto/EmailEditDto.java
+++ b/be/src/main/java/capstone/be/domain/user/dto/EmailEditDto.java
@@ -1,0 +1,12 @@
+package capstone.be.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EmailEditDto {
+    private String email;
+}

--- a/be/src/main/java/capstone/be/domain/user/dto/NicknameEditDto.java
+++ b/be/src/main/java/capstone/be/domain/user/dto/NicknameEditDto.java
@@ -1,0 +1,12 @@
+package capstone.be.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NicknameEditDto {
+    private String nickname;
+}

--- a/be/src/main/java/capstone/be/domain/user/service/EditUserService.java
+++ b/be/src/main/java/capstone/be/domain/user/service/EditUserService.java
@@ -1,0 +1,69 @@
+package capstone.be.domain.user.service;
+
+import capstone.be.domain.user.domain.User;
+import capstone.be.domain.user.dto.EmailEditDto;
+import capstone.be.domain.user.dto.NicknameEditDto;
+import capstone.be.domain.user.repository.UserRepository;
+import capstone.be.global.advice.exception.CEmailSignupFailedException;
+import capstone.be.global.advice.exception.CNicknameSignupFailedException;
+import capstone.be.global.advice.exception.CUserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EditUserService {
+    private final UserRepository userRepository;
+
+    //닉네임 변경
+    @Transactional
+    public NicknameEditDto editNickname(Long userId, String nickname) {
+        User user = userRepository.findById(userId).orElseThrow(CUserNotFoundException::new);
+
+        Optional<User> otherUser = userRepository.findByNickname(nickname);
+
+        if (otherUser.isEmpty()){//중복되지 않는 닉네임
+            user.setNickname(nickname);//닉네임 수정
+        }else{
+            throw new CNicknameSignupFailedException();
+        }
+
+        //닉네임 형식 오류(닉네임 형식 추가되면 그때 구현하기로)
+
+        userRepository.save(user);//트랜잭션 있어서 없어도 저장되긴 함
+
+        return new NicknameEditDto(user.getNickname());
+    }
+
+    //이메일 변경
+    @Transactional
+    public EmailEditDto editEmail(Long userId, String email) {
+        User user = userRepository.findById(userId).orElseThrow(CUserNotFoundException::new);
+
+        Optional<User> otherUser = userRepository.findByEmail(email);
+
+        if (otherUser.isEmpty()){//중복되지 않는 이메일
+            user.setEmail(email);//닉네임 수정
+        }else{
+            throw new CEmailSignupFailedException();
+        }
+
+        //이메일 형식 오류(이메일 형식 추가되면 그때 구현하기로)
+
+        userRepository.save(user);//트랜잭션 있어서 없어도 저장되긴 함
+
+        return new EmailEditDto(user.getEmail());
+    }
+
+    //회원 탈퇴
+    @Transactional
+    public void deleteUser(Long userId){
+        User user = userRepository.findById(userId).orElseThrow(CUserNotFoundException::new);
+        userRepository.delete(user); //유저 정보 삭제
+    }
+}


### PR DESCRIPTION
1. 코드 추가/변경 이유가 무엇인지?
이메일, 닉네임 수정 기능 구현

2. 코드 주요 구현 사항이 무엇인지?
사용자가 마이페이지에서 이메일과 닉네임을 수정할 수 있게 한다.

3. 리뷰어가 확인할 사항, 전달사항
 회원 탈퇴는 uri 에 맞게 SignController로 옮겨야 할 것 같음.(일단 코드 리뷰할 때 보기 편하도록 한 파일에 넣어뒀음
유저 정보 delete 후 토큰을 삭제해야 할 것 같은데, 당장은 유저 데이터만 삭제하도록 했음.
유저를 찾을 수 없을 때 발생하는 exception이 에러코드에 적힌 AUTH_010에 해당하는 것 같음. yml에 적힌 이름을 바꾸는 게 좋지 않을까?

close #9 